### PR TITLE
Add sudoers rule for passwordless drop of cache. Implement it in daq …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ LIBS=-lz -pthread -lrno-g -lradiant -lrno-g-cal -lconfig -lflower -lm -lsystemd
 
 INCLUDES=src/ice-config.h src/ice-buf.h src/ice-common.h
 
-.PHONY: all clean install uninstall setup cfg-update cfg-install cppcheck service-install cfg-round-trip-check
+.PHONY: all clean install uninstall setup cfg-update cfg-install cppcheck service-install sudoers-install polkit-install cfg-round-trip-check
 
 OBJS:=$(addprefix $(BUILD_DIR)/, ice-config.o ice-buf.o ice-common.o ice-version.o)
 
@@ -99,6 +99,10 @@ cppcheck:
 polkit-install:
 	install polkit/rno-g.rules /etc/polkit-1/rules.d/10-rno-g.rules
 
-service-install: polkit-install
+sudoers-install:
+	install -m 0440 sudoers/rno-g-drop-caches /etc/sudoers.d/rno-g-drop-caches
+	visudo -cf /etc/sudoers.d/rno-g-drop-caches
+
+service-install: polkit-install sudoers-install
 	install systemd/*.service systemd/*.timer /etc/systemd/system
 	systemctl daemon-reload

--- a/src/rno-g-acq.c
+++ b/src/rno-g-acq.c
@@ -2017,14 +2017,16 @@ static int initial_setup()
 
     if (!radiant)
     {
-      fprintf(stderr, "COULD NOT OPEN RADIANT. Attemping to drop caches in case kernel fragmentation is the issue.");
+      fprintf(stderr, "COULD NOT OPEN RADIANT. Attempting to drop caches in case kernel fragmentation is the issue.\n");
       if (nattempts++ > 3)
       {
         fprintf(stderr, "Giving up...\n");
         return 1;
       }
       sleep(1);
-      system("/rno-g/bin/bbb-drop-caches");
+      // Drop the VM page cache via passwordless sudo (see sudoers/rno-g-drop-caches).
+      // Paths are absolute to match the sudoers rule exactly under the minimal PATH.
+      system("/usr/bin/sudo /usr/sbin/sysctl -w vm.drop_caches=3");
     }
 
     if (radiant && nattempts > 0)

--- a/sudoers/rno-g-drop-caches
+++ b/sudoers/rno-g-drop-caches
@@ -1,0 +1,10 @@
+# RNO-G specific sudoers rule for dropping the VM page cache without a password.
+#
+# Equivalent to `echo 3 > /proc/sys/vm/drop_caches`, but written as a single
+# sysctl command so the shell redirect (which sudo cannot perform) is avoided
+# and sudoers can match the full command line exactly.
+#
+# Usage: sudo sysctl -w vm.drop_caches=3
+#
+# Installed to /etc/sudoers.d/rno-g-drop-caches (see `make sudoers-install`).
+%rno-g ALL=(root) NOPASSWD: /usr/sbin/sysctl -w vm.drop_caches=3


### PR DESCRIPTION
…software and makefile

@cozzyd - some suggestion from my AI to try to fix the automatic dropping of cache and / or allowing to drop cache without password. Is not tested. Will first test the new command (without password) when it happens next and afterwards try to deploy this on one station. 

Any concerns? 